### PR TITLE
Fixing issues #8/#35

### DIFF
--- a/src/site/scripts/components/footer.tsx
+++ b/src/site/scripts/components/footer.tsx
@@ -16,5 +16,8 @@ export const Footer: React.StatelessComponent<void> = (): JSX.Element => {
                 <br />
                 Kill someone by tagging them with your badge. You'll then receive their old target as your own.
             </p>
+            <p>
+                For feedback/comments send mail to <a href="mailto:iscassassingame2016@service.microsoft.com">ISC Assassin Game 2016</a>
+            </p>
         </footer>);
 };

--- a/src/site/scripts/components/profile/actionbutton.tsx
+++ b/src/site/scripts/components/profile/actionbutton.tsx
@@ -125,11 +125,29 @@ export class ActionButton extends React.Component<IActionButtonProps, IActionBut
         }
 
         return (
+            <div className="action-confirmation">
             <input
-                className="action-confirmation"
                 onClick={onClick}
                 type="button"
-                value={value} />);
+                value={value} />
+                {this.renderCancel()}
+            </div>);
+    }
+
+    private renderCancel(): JSX.Element {
+        let onClick: () => void;
+
+        if (this.state.expanded) {
+            onClick = (): void => {
+                this.toggleExpansion();
+            };
+        }
+
+        return (
+          <input
+            onClick={onClick}
+            type="button"
+            value="Cancel"/>);
     }
 
     /**
@@ -139,7 +157,8 @@ export class ActionButton extends React.Component<IActionButtonProps, IActionBut
         if (this.state.expanded) {
             this.setState({
                 confirmation: this.state.confirmation,
-                expanded: false
+                expanded: false,
+                delay: 0
             });
 
             return;


### PR DESCRIPTION
#35 is pretty self explanatory. 

#8 I put my reasoning in the commit message, but in any case I went with the word "Cancel" instead of an X, just because it looks like we're not done designing what the confirmation thing should look like. Plus it's just easier to use. 

