### PR TITLE
Added users back to the admin page

### DIFF
--- a/src/site/scripts/components/admin/userstable.tsx
+++ b/src/site/scripts/components/admin/userstable.tsx
@@ -14,6 +14,11 @@ export interface IUsersTableProps {
     fields: string[];
 
     /**
+     * Optional filter to restrict users listed.
+     */
+    filter?: IUserFilter;
+
+    /**
      * Title to to display.
      */
     heading: string;
@@ -25,16 +30,45 @@ export interface IUsersTableProps {
 }
 
 /**
+ * Checks if a user should be displayed in a table.
+ * 
+ * @param user   User attributes being filtered.
+ * @returns Whether the user should be displayed.
+ */
+export interface IUserFilter {
+    (user: IUser): boolean;
+}
+
+/**
  * Component for an administrative table of users.
  */
 export class UsersTable extends React.Component<IUsersTableProps, void> {
+    /**
+     * User filter to allow only non-admin users.
+     * 
+     * @param user   User attributes being filtered.
+     * @returns Whether the user should be displayed.
+     */
+    public static filterToNonAdminUsers(user: IUser): boolean {
+        return !user.admin;
+    }
+
+    /**
+     * User filter to allow only admin users.
+     * 
+     * @param user   User attributes being filtered.
+     * @returns Whether the user should be displayed.
+     */
+    public static filterToAdminUsers(user: IUser): boolean {
+        return !!user.admin;
+    }
+
     /**
      * Renders the component.
      * 
      * @returns The rendered component.
      */
     public render(): JSX.Element {
-
         return (
             <div class="users-table">
                 <h3>{this.props.heading}</h3>
@@ -83,7 +117,11 @@ export class UsersTable extends React.Component<IUsersTableProps, void> {
      * @returns The rendered body component.
      */
     private renderBody(): JSX.Element[] {
-        return this.props.users
+        const users: IUser[] = this.props.filter
+            ? this.props.users.filter(this.props.filter)
+            : this.props.users;
+
+        return users
             .map((user: IUser, i: number): JSX.Element => {
                 return <tr key={i}>{this.renderUser(user)}</tr>;
             });
@@ -97,8 +135,9 @@ export class UsersTable extends React.Component<IUsersTableProps, void> {
      */
     private renderUser(user: IUser): JSX.Element[] {
         return this.props.fields
-            .filter((field: string): boolean => user.hasOwnProperty[field])
+            .filter((field: string): boolean => user.hasOwnProperty(field))
             .map((field: string, i: number): JSX.Element => {
+                console.log("Rendering field", field, i);
                 return <td key={i}>{user[field].toString()}</td>;
             });
     }

--- a/src/site/scripts/components/admin/userstable.tsx
+++ b/src/site/scripts/components/admin/userstable.tsx
@@ -131,13 +131,12 @@ export class UsersTable extends React.Component<IUsersTableProps, void> {
      * Renders a single user's row.
      * 
      * @param user   Information on a user.
-     * 
+     * @returns The rendered user row.
      */
     private renderUser(user: IUser): JSX.Element[] {
         return this.props.fields
             .filter((field: string): boolean => user.hasOwnProperty(field))
             .map((field: string, i: number): JSX.Element => {
-                console.log("Rendering field", field, i);
                 return <td key={i}>{user[field].toString()}</td>;
             });
     }

--- a/src/site/scripts/components/admin/userstables.tsx
+++ b/src/site/scripts/components/admin/userstables.tsx
@@ -75,14 +75,17 @@ export class UsersTables extends React.Component<IUsersTablesProps, IUsersTables
             <div id="administration">
                 <UsersTable
                     fields={["alias", "nickname", "target"]}
+                    filter={UsersTable.filterToNonAdminUsers}
                     heading="Alive"
                     users={this.state.users.filter(user => user.alive)} />
                 <UsersTable
                     fields={["alias", "nickname"]}
+                    filter={UsersTable.filterToNonAdminUsers}
                     heading="Dead"
                     users={this.state.users.filter(user => !user.alive)} />
                 <UsersTable
                     fields={["alias", "nickname"]}
+                    filter={UsersTable.filterToAdminUsers}
                     heading="Admins"
                     users={this.state.users.filter(user => user.admin)} />
             </div>);


### PR DESCRIPTION
Turns out I'd made a typo by calling `hasOwnProperty[field]` (square
brackets instead of parenthesis). Also added filtering to the tables so
admins don't show up in the alive/dead tables.

Fixes #92.