### PR TITLE
Prettified kill claims on user profiles

### DIFF
--- a/src/shared/kills.ts
+++ b/src/shared/kills.ts
@@ -13,4 +13,9 @@ export interface IKillClaim {
      * Rest in potatoes.
      */
     victim: string;
+
+    /**
+     * When the deed took place.
+     */
+    timestamp: number;
 }

--- a/src/site/scripts/components/profile/killclaimreports.tsx
+++ b/src/site/scripts/components/profile/killclaimreports.tsx
@@ -44,6 +44,7 @@ export class KillClaimReports extends React.Component<IKillClaimReportsProps, vo
 
         return (
             <div className="kill-claim-reports">
+                {this.renderStatistics(this.props.killClaims)}
                 {Object.keys(collectedReports)
                     .map((key: string): JSX.Element => {
                         return (
@@ -52,6 +53,38 @@ export class KillClaimReports extends React.Component<IKillClaimReportsProps, vo
                                 {this.renderKillClaimsGroup(collectedReports[key])}
                             </div>);
                     })}
+            </div>);
+    }
+
+    /**
+     * Renders a statistics section for kill claims.
+     * 
+     * @param killClaims   Kill claims to summarize.
+     * @returns The rendered statistics section.
+     */
+    private renderStatistics(killClaims: IKillClaim[]): JSX.Element {
+        const relevantClaims: IKillClaim[] = killClaims
+            .filter((killClaim: IKillClaim): boolean => {
+                return killClaim.killer === this.props.user.alias && killClaim.killer !== killClaim.victim;
+            })
+            .sort((a: IKillClaim, b: IKillClaim): number => b.timestamp - a.timestamp);
+
+        if (relevantClaims.length === 0) {
+            return <p className="kill-claim-statistics">You haven't killed anybody yet... Get cracking!</p>;
+        }
+
+        const oldestClaimDate: moment.Moment = Moment(relevantClaims[0].timestamp);
+        const newestClaimDate: moment.Moment = Moment(relevantClaims[relevantClaims.length - 1].timestamp);
+        const numberOfDays: number = oldestClaimDate.diff(newestClaimDate, "days") + 1;
+        const killsDescriptor: string = relevantClaims.length === 1 ? "person" : "people";
+        const daysPerKill: number = Math.round(numberOfDays / relevantClaims.length);
+        const daysDescriptor: string = daysPerKill === 1 ? "day" : "days";
+
+        return (
+            <div className="kill-claim-statistics">
+                <span>You've killed <strong>{relevantClaims.length}</strong> {killsDescriptor}.</span>
+                <br />
+                <span>That's {daysPerKill} {daysDescriptor} per kill.</span> 
             </div>);
     }
 

--- a/src/site/scripts/components/profile/killclaimreports.tsx
+++ b/src/site/scripts/components/profile/killclaimreports.tsx
@@ -3,8 +3,10 @@
 /// <reference path="../../../../../typings/react-dom/index.d.ts" />
 
 "use strict";
+import * as Moment from "moment";
 import * as React from "react";
 import { IKillClaim } from "../../../../shared/kills";
+import { IUser } from "../../../../shared/users";
 
 /**
  * Props for a KilClaimReports component.
@@ -14,6 +16,18 @@ export interface IKillClaimReportsProps {
      * A user's relevant kill claims.
      */
     killClaims: IKillClaim[];
+
+    /**
+     * The user who made the claims.
+     */
+    user: IUser;
+}
+
+/**
+ * Kill claims keyed by a description of the date they took place.
+ */
+interface ICollectedKillClaims {
+    [i: string]: IKillClaim[];
 }
 
 /**
@@ -26,44 +40,75 @@ export class KillClaimReports extends React.Component<IKillClaimReportsProps, vo
      * @returns The rendered component.
      */
     public render(): JSX.Element {
+        const collectedReports: ICollectedKillClaims = this.collectKillClaims(this.props.killClaims);
+
         return (
             <div className="kill-claim-reports">
-                {this.props.killClaims.map(
-                    (killClaim: IKillClaim, i: number): JSX.Element => {
-                        return killClaim.killer
-                            ? this.renderKillerReport(killClaim, i)
-                            : this.renderVictimReport(killClaim, i);
+                {Object.keys(collectedReports)
+                    .map((key: string): JSX.Element => {
+                        return (
+                            <div className="kill-claim-group" key={key}>
+                                <h3>{key}</h3>
+                                {this.renderKillClaimsGroup(collectedReports[key])}
+                            </div>);
                     })}
             </div>);
     }
 
     /**
-     * Renders a report where the user is the killer.
+     * Renders a group of kill claims.
      * 
-     * @param report   A kill claim report.
-     * @param i   Which index number this is.
-     * @returns The rendered report.
+     * @param killClaims   Kill claims to render.
+     * @returns The rendered kill claims.
      */
-    private renderKillerReport(report: IKillClaim, i: number): JSX.Element {
-        const victim: string = report.victim;
+    private renderKillClaimsGroup(killClaims: IKillClaim[]): JSX.Element[] {
+        return killClaims
+            .sort((a: IKillClaim, b: IKillClaim): number => b.timestamp - a.timestamp)
+            .map((killClaim: IKillClaim, i: number): JSX.Element => this.renderKillClaim(killClaim, i));
+    }
+
+    /**
+     * Renders a single kill claim.
+     * 
+     * @param killClaim   The kill claim.
+     * @param i   The claim's index in its container.
+     * @returns The rendered kill claim.
+     */
+    private renderKillClaim(killClaim: IKillClaim, i: number): JSX.Element {
+        const descriptor = killClaim.victim === this.props.user.alias
+            ? `You were killed by ${killClaim.killer} :(`
+            : `You killed ${killClaim.victim}`;
 
         return (
-            <div className="kill-claim-report killer-report" key={i}>
-                You reported killing {victim}.
+            <div className="kill-claim" key={i}>
+                {descriptor}
             </div>);
     }
 
     /**
-     * Renders a report where the user is the victim.
+     * Groups kill claims by their date descriptors (rounded to the nearest day).
      * 
-     * @param report   A kill claim report.
-     * @param i   Which index number this is.
-     * @returns The rendered report.
+     * @param killClaims   Kill claims to collect.
+     * @returns The kill claims, collected by their date descriptors.
      */
-    private renderVictimReport(report: IKillClaim, i: number): JSX.Element {
-        return (
-            <div className="kill-claim-report victim-report" key={i}>
-                Your killer has reported killing you.
-            </div>);
+    private collectKillClaims(killClaims: IKillClaim[]): ICollectedKillClaims {
+        const collection: ICollectedKillClaims = {};
+
+        for (const killClaim of killClaims) {
+            if (killClaim.killer === killClaim.victim) {
+                continue;
+            }
+
+            const killDay: moment.Moment = Moment(killClaim.timestamp).startOf("day");
+            const descriptor = killDay.calendar().split(" at ")[0];
+
+            if (!collection.hasOwnProperty(descriptor)) {
+                collection[descriptor] = [killClaim];
+            } else {
+                collection[descriptor].push(killClaim);
+            }
+        }
+
+        return collection;
     }
 }

--- a/src/site/scripts/components/profile/profile.tsx
+++ b/src/site/scripts/components/profile/profile.tsx
@@ -3,7 +3,6 @@
 
 "use strict";
 import * as React from "react";
-import { IKillClaim } from "../../../../shared/kills";
 import { IAppUserProps } from "../apps/appuser";
 import { Actions } from "./actions";
 import { Greeting } from "./greeting";
@@ -52,22 +51,21 @@ export class Profile extends React.Component<IAppUserProps, void> {
                         onKill={(): void => { this.onKill(); }} />
                 </div>
 
-                {this.renderKillClaimReports(this.props.killClaims)}
+                {this.renderKillClaimReports()}
             </section>);
     }
 
     /**
      * Renders the user's active kill claim reports, if there are any.
      * 
-     * @param The user's relevant kill claim reports.
      * @returns The rendered kill claim reports.
      */
-    private renderKillClaimReports(killClaims: IKillClaim[]): JSX.Element {
-        if (!killClaims || !killClaims.length) {
+    private renderKillClaimReports(): JSX.Element {
+        if (!this.props.killClaims || !this.props.killClaims.length) {
             return undefined;
         }
 
-        return <KillClaimReports killClaims={killClaims} />;
+        return <KillClaimReports killClaims={this.props.killClaims} user={this.props.user} />;
     }
 
     /**
@@ -80,7 +78,8 @@ export class Profile extends React.Component<IAppUserProps, void> {
             this.props.user,
             {
                 killer: this.props.user.alias,
-                victim: this.props.user.alias
+                victim: this.props.user.alias,
+                timestamp: Date.now()
             });
 
         this.props.refreshUserData();
@@ -96,7 +95,8 @@ export class Profile extends React.Component<IAppUserProps, void> {
             this.props.user,
             {
                 killer: this.props.user.alias,
-                victim: this.props.user.target
+                victim: this.props.user.target,
+                timestamp: Date.now()
             });
 
         this.props.refreshUserData();

--- a/test/integration/features/kills.feature
+++ b/test/integration/features/kills.feature
@@ -1,16 +1,22 @@
 Feature: Kill claims
     Tests for the kills endpoint
 
-    Scenario: Unconfirmed kill claim
+    Scenario: Unconfirmed killer claim
         Given I am a killer
         When I send a kill claim
         Then I should have 0 kills
 
-    Scenario: Successful kill claim
+    Scenario: Confirmed killer claim
         Given I am a killer
-        When I send a kill claim
+        When I self-report a kill claim
         And the victim confirms the kill claim
         Then I should have 1 kill
+
+    Scenario: Self-reported victim claim
+        Given I am a victim
+        When I send a kill claim
+        Then I should be dead
+        And my killer should have 1 kill
 
     Scenario: Invalid kill claim
         Given I am a killer

--- a/test/integration/steps/kills.js
+++ b/test/integration/steps/kills.js
@@ -7,8 +7,16 @@ module.exports = function () {
         return this.setUserTypeAsKiller();
     });
 
+    this.Given(/^I am a victim$/, function () {
+        return this.setUserTypeAsVictim();
+    });
+
     this.When(/^I send a kill claim$/, function () {
         return this.sendKillerKillClaim();
+    });
+
+    this.When(/^I self-report a kill claim$/, function () {
+        return this.sendVictimKillClaim();
     });
 
     this.When(/^the victim confirms the kill claim$/, function () {
@@ -23,8 +31,16 @@ module.exports = function () {
         return this.sendUnauthorizedKillClaim();
     });
 
+    this.Then(/^I should be dead?$/, function (killsCount) {
+        return this.assertVictimDeath();
+    });
+
     this.Then(/^I should have (.*) kills?$/, function (killsCount) {
-        return this.assertKillsCount(parseInt(killsCount));
+        return this.assertKillerKillsCount(parseInt(killsCount));
+    });
+
+    this.Then(/^my killer should have (.*) kills?$/, function (killsCount) {
+        return this.assertKillerKillsCount(parseInt(killsCount));
     });
 
     this.Then(/^it should have failed as invalid$/, function () {

--- a/test/integration/support/kills.js
+++ b/test/integration/support/kills.js
@@ -48,6 +48,15 @@ class KillsWorld extends World {
     }
 
     /**
+     * Adds the killer and victim to the server.
+     * 
+     * @returns {Promise} A promise for the users being added.
+     */
+    setUserTypeAsVictim() {
+        return this.setUserTypeAsKiller();
+    }
+
+    /**
      * Sends a kill claim as the killer.
      * 
      * @returns {Promise} A promise for the kill claim.
@@ -129,7 +138,7 @@ class KillsWorld extends World {
      * @param {number} count   How many kills the user should have.
      * @returns {Promise} A promise for asserting the number of kills.
      */
-    assertKillsCount(count) {
+    assertKillerKillsCount(count) {
         this.credentials = {
             alias: killer.alias,
             nickname: killer.nickname,
@@ -138,6 +147,23 @@ class KillsWorld extends World {
 
         return this.sendRequest("GET", "api/user")
             .then(() => expect(this.response.body.kills).to.be.equal(count));
+    }
+
+    /**
+     * Asserts the victim is dead.
+     * 
+     * @param {number} count   How many kills the user should have.
+     * @returns {Promise} A promise for asserting the number of kills.
+     */
+    assertVictimDeath(count) {
+        this.credentials = {
+            alias: victim.alias,
+            nickname: victim.nickname,
+            passphrase: victim.passphrase
+        };
+
+        return this.sendRequest("GET", "api/user")
+            .then(() => expect(this.response.body.alive).to.be.equal(false));
     }
 
     /**


### PR DESCRIPTION
They now include a `timestamp` field and are visually grouped by their approximate day. There's also a small statistics section with number and rate of kills.

Fixes #46 