### PR TITLE
Added babel and bluebird for browser support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+const babelify = require("babelify");
 const browserify = require("browserify");
 const fs = require("fs");
 const gulp = require("gulp");
@@ -18,6 +19,7 @@ gulp.task("browserify", () => {
         });
 
     return browsering
+        .transform("babelify", { presets: ["es2015"] })
         .bundle()
         .pipe(source("main.js"))
         .pipe(gulp.dest("src/site/scripts/bundled"));

--- a/package.json
+++ b/package.json
@@ -12,9 +12,15 @@
     "url": "https://github.com/JoshuaKGoldberg/intern-assassins/issues"
   },
   "homepage": "https://github.com/JoshuaKGoldberg/intern-assassins#readme",
-  "devDependencies": {
+  "dependencies": {
+    "babel-polyfill": "^6.9.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babelify": "^7.3.0",
+    "bluebird": "^3.4.1",
+    "body-parser": "^1.15.1",
     "browserify": "^13.0.1",
     "chai": "^3.5.0",
+    "express": "^4.13.4",
     "fs-promise": "^0.5.0",
     "gulp": "^3.9.1",
     "gulp-cucumber": "0.0.21",
@@ -24,26 +30,20 @@
     "gulp-typescript": "^2.13.4",
     "less": "^2.7.1",
     "moment": "^2.13.0",
-    "mongodb": "^2.1.18",
-    "request-promise": "^3.0.0",
-    "run-sequence": "^1.2.0",
-    "tslint": "^3.10.2",
-    "typescript": "^1.8.10",
-    "typings": "^1.0.4",
-    "vinyl-source-stream": "^1.1.0"
-  },
-  "dependencies": {
-    "body-parser": "^1.15.1",
-    "express": "^4.13.4",
-    "moment": "^2.13.0",
     "mongod": "^1.3.0",
     "mongodb": "^2.1.18",
     "mongoose": "^4.4.20",
+    "request-promise": "^3.0.0",
+    "run-sequence": "^1.2.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-dropzone": "^3.5.1",
     "requirejs": "^2.2.0",
     "socket.io": "^1.4.6",
-    "socket.io-client": "^1.4.6"
+    "socket.io-client": "^1.4.6",
+    "tslint": "^3.10.2",
+    "typescript": "1.8.10",
+    "typings": "^1.0.4",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,7 @@
+/// <reference path="../typings/bluebird/index.d.ts" />
+
 "use strict";
+import * as Promise from "bluebird";
 import { IServerSettings, Server } from "./server/server";
 import { IDatabaseSettings } from "./server/database";
 
@@ -25,7 +28,7 @@ export const settingsFilePath: string = "assassins.json";
 /**
  * Promise for the server.
  */
-export const serverPromise: Promise<Server> = (async () => {
+export const serverPromise: Promise<Server> = (async (): Promise<Server> => {
     return Server.createFromFile(settingsFilePath);
 })();
 

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -1,6 +1,7 @@
-/// <reference path="../../typings/all.d.ts" />
+/// <reference path="../../typings/bluebird/index.d.ts" />
 
 "use strict";
+import * as Promise from "bluebird";
 import { Collection, Db, MongoClient, MongoError } from "mongodb";
 
 /**

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -23,6 +23,7 @@
             <div id="footer-wrapper"></div>
         </div>
 
+        <script type="text/javascript" src="/node_modules/babel-polyfill/dist/polyfill.min.js"></script>
         <script type="text/javascript" src="/socket.io/socket.io.js"></script>
         <script type="text/javascript" data-main="scripts/index" src="../../node_modules/requirejs/require.js"></script>
     </body>


### PR DESCRIPTION
We now use the 2015 babel presets with a promise polyfill (bluebird) so IE loads.

Also combined all node modules in package.json into dependencies. We can sort that out later.