### PR TITLE
Added hacky setup script for react-min, react-dom-min

### DIFF
--- a/hacky-setup.cmd
+++ b/hacky-setup.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+REM react
+move .\node_modules\react\dist\react.js .\node_modules\react\dist\react-save.js 
+copy .\node_modules\react\dist\react.min.js .\node_modules\react\dist\react.js
+
+REM react-dom
+move .\node_modules\react-dom\dist\react-dom.js .\node_modules\react-dom\dist\react-dom-save.js 
+copy .\node_modules\react-dom\dist\react-dom.min.js .\node_modules\react-dom\dist\react-dom.js 

--- a/src/site/scripts/index.ts
+++ b/src/site/scripts/index.ts
@@ -1,13 +1,3 @@
 declare var requirejs: any;
 
-requirejs.config({
-    paths: {
-        "main": "bundled/main",
-        "jszip": "../../../node_modules/xlsx/dist/jszip",
-        "react": "../../../node_modules/react/dist/react",
-        "react-dom": "../../../node_modules/react-dom/dist/react-dom",
-        "xlsx": "../../../node_modules/xlsx/dist/xlsx.core.min"
-    }
-});
-
-requirejs(["main"]);
+requirejs(["bundled/main"]);


### PR DESCRIPTION
I can't get browserify to work with these so I'm time boxing this
investigation with a hacky fix for the VM.

Run `hacky-setup.cmd` to replace the debug versions of react and
react-dom in node_modules with their .min equivalents.

Fixes #130.
Opens #151.