### PR TITLE
Changed json settings for rounds to use "LLLL" dates

### DIFF
--- a/assassins.default.json
+++ b/assassins.default.json
@@ -12,16 +12,21 @@
       }
     ],
     "email": {
-      "cc": [],
-      "domain": "",
-      "transporter": {},
-      "website": "localhost:3000"
+      "cc": ["your@email.com"],
+      "domain": "@email.com",
+      "website": "localhost"
     },
     "port": 3000,
     "reset": true,
     "rounds": [{
-      "end": 1687855086839,
-      "start": 1687853086839
+      "end": "Friday, July 8, 2016 12:01 AM",
+      "start": "Friday, July 1, 2016 12:01 AM"
+    }, {
+      "end": "Friday, July 15, 2016 12:01 AM",
+      "start": "Friday, July 8, 2016 12:01 AM"
+    }, {
+      "end": "Friday, July 22, 2016 12:01 AM",
+      "start": "Friday, July 15, 2016 12:01 AM"
     }],
     "users": [
       {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5,7 +5,7 @@ import * as express from "express";
 import * as fsp from "fs-promise";
 import * as http from "http";
 import { INotification } from "../shared/notifications";
-import { IRound } from "../shared/rounds";
+import { IRawRound } from "../shared/rounds";
 import { IUser } from "../shared/users";
 import { IAssassinsSettings } from "../main";
 import { Scheduler } from "./cron/scheduler";
@@ -48,7 +48,7 @@ export interface IServerSettings {
     /**
      * Game rounds.
      */
-    rounds: IRound[];
+    rounds: IRawRound[];
 
     /**
      * Users to add when resetting the database.

--- a/src/shared/rounds.ts
+++ b/src/shared/rounds.ts
@@ -1,6 +1,21 @@
 "use strict";
 
 /**
+ * JSON-friendly raw description of a round.
+ */
+export interface IRawRound {
+    /**
+     * Ending time of the round in "LLLL" date format.
+     */
+    end: string;
+
+    /**
+     * Starting time of the round in "LLLL" date format.
+     */
+    start: string;
+}
+
+/**
  * A single round of gameplay.
  */
 export interface IRound {

--- a/src/site/scripts/components/apps/appanonymous.tsx
+++ b/src/site/scripts/components/apps/appanonymous.tsx
@@ -1,4 +1,3 @@
-/// <reference path="../../../../../typings/moment/index.d.ts" />
 /// <reference path="../../../../../typings/react/index.d.ts" />
 
 "use strict";


### PR DESCRIPTION
There's now a difference between an `IRound` and an `IRawRound`, such
that the former uses standard timestamps and the latter uses "LLLL"
formatted dates courtesy of momentjs.

Updated assassins.default.json to be immediately usable with them.

Fixes #148.