### PR TITLE
Pending kill claims

### DIFF
--- a/src/server/cron/scheduler.ts
+++ b/src/server/cron/scheduler.ts
@@ -69,7 +69,7 @@ export class Scheduler {
                 return this.delay(
                     parseInt(time),
                     async (): Promise<void> => {
-                        if (await chain[time]()) {
+                        if (!(await chain[time]())) {
                             return;
                         }
 

--- a/src/server/endpoints/claimsendpoint.ts
+++ b/src/server/endpoints/claimsendpoint.ts
@@ -129,6 +129,30 @@ export class ClaimsEndpoint extends Endpoint<IClaim> {
     }
 
     /**
+     * Deletes a kill claim.
+     * 
+     * @param credentials   Login values for authentication.
+     * @param claim   A claim to delete.
+     * @returns A promise for deleting the claim.
+     */
+    public async delete(credentials: ICredentials, claim: IClaim): Promise<void> {
+        await this.validateAdminCredentials(credentials);
+        await this.collection.deleteOne(claim);
+    }
+
+    /**
+     * Deletes all claims against a victim.
+     * 
+     * @param victim   A user the claims are against.
+     * @returns A promise for deleting the claims.
+     */
+    public async deleteClaimsAgainst(victim: IUser): Promise<void> {
+        await this.collection.deleteMany({
+            victim: victim.alias
+        });
+    }
+
+    /**
      * Validates that a kill claim has the required fields.
      */
     private validateClaim(claim: IClaim): void {
@@ -156,8 +180,7 @@ export class ClaimsEndpoint extends Endpoint<IClaim> {
     private scheduleFollowupReminders(killer: IUser, victim: IUser): void {
         this.api.scheduler.delayChain({
             [Delay.minute * 10]: async (): Promise<boolean> => {
-                const victimLater: IUser = await this.api.endpoints.users.getByAlias(victim.alias);
-                if (!victimLater.alive) {
+                if (!(await this.isClaimStillOpen(killer.alias, victim.alias))) {
                     return true;
                 }
 
@@ -177,8 +200,7 @@ export class ClaimsEndpoint extends Endpoint<IClaim> {
                 return false;
             },
             [Delay.hour]: async (): Promise<boolean> => {
-                const victimLater: IUser = await this.api.endpoints.users.getByAlias(victim.alias);
-                if (!victimLater.alive) {
+                if (!(await this.isClaimStillOpen(killer.alias, victim.alias))) {
                     return true;
                 }
 
@@ -198,8 +220,7 @@ export class ClaimsEndpoint extends Endpoint<IClaim> {
                 return false;
             },
             [Delay.hour * 3]: async (): Promise<boolean> => {
-                const victimLater: IUser = await this.api.endpoints.users.getByAlias(victim.alias);
-                if (!victimLater.alive) {
+                if (!(await this.isClaimStillOpen(killer.alias, victim.alias))) {
                     return true;
                 }
 
@@ -221,5 +242,16 @@ export class ClaimsEndpoint extends Endpoint<IClaim> {
                 return false;
             }
         });
+    }
+
+    /**
+     * Determines if there's still a claim between users.
+     * 
+     * @param killer   Alias of a killer.
+     * @param killer   Alias of a vitim.
+     * @returns A promise for whether there's a claim between users.
+     */
+    private async isClaimStillOpen(killer: string, victim: string): Promise<boolean> {
+        return !!(await this.collection.find({ killer, victim }));
     }
 }

--- a/src/server/endpoints/claimsendpoint.ts
+++ b/src/server/endpoints/claimsendpoint.ts
@@ -163,9 +163,12 @@ export class ClaimsEndpoint extends Endpoint<IClaim> {
      * @param victim   A user the claims are against.
      * @returns A promise for deleting the claims.
      */
-    public async deleteClaimsAgainst(victim: IUser): Promise<void> {
+    public async deleteClaimsWith(victim: IUser): Promise<void> {
         await this.collection.deleteMany({
             victim: victim.alias
+        });
+        await this.collection.deleteMany({
+            killer: victim.alias
         });
     }
 

--- a/src/server/endpoints/killsendpoint.ts
+++ b/src/server/endpoints/killsendpoint.ts
@@ -78,10 +78,11 @@ export class KillsEndpoint extends Endpoint<IKill> {
         killer.target = victim.target;
         await this.api.endpoints.users.update(killer);
 
-        // Update the victim: no longer alive or with a target
+        // Update the victim: no longer alive with a target or any claims
         victim.alive = false;
         victim.target = "";
         await this.api.endpoints.users.update(victim);
+        await this.api.endpoints.claims.deleteClaimsWith(victim);
 
         await this.api.fireNotificationCallbacks({
             cause: NotificationCause.Kill,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -109,9 +109,9 @@ export class Server {
         this.app.use(express.static("src/site"));
         this.app.use("/node_modules", express.static("node_modules"));
 
-        this.api = new Api(this.app, this.database, this.scheduler);
-        this.server = http.createServer(this.app);
         this.scheduler = new Scheduler();
+        this.server = http.createServer(this.app);
+        this.api = new Api(this.app, this.database, this.scheduler);
 
         this.notificationsHub = new NotificationsHub();
         this.notificationsHub.registerNotifier(new EndpointNotifier(this.api.endpoints.notifications));

--- a/src/site/scripts/components/admin/claimstable.tsx
+++ b/src/site/scripts/components/admin/claimstable.tsx
@@ -42,7 +42,24 @@ export class ClaimsTable extends React.Component<IClaimsTableProps, IClaimsTable
      */
     public render(): JSX.Element {
         return (
-            <table className="claims-table">
+            <div className="claims-table">
+                <h3>Claims</h3>
+                {this.renderClaims()}
+            </div>);
+    }
+
+    /**
+     * Renders claims, if there are any.
+     * 
+     * @returns The rendered claims.
+     */
+    public renderClaims(): JSX.Element {
+        if (!this.props.claims.length) {
+            return <em>Nothing right now...</em>;
+        }
+
+        return (
+            <table>
                 <thead>
                     <tr>
                         <th>Killer</th>

--- a/src/site/scripts/components/admin/claimstable.tsx
+++ b/src/site/scripts/components/admin/claimstable.tsx
@@ -1,0 +1,77 @@
+/// <reference path="../../../../../typings/react/index.d.ts" />
+
+"use strict";
+import * as React from "react";
+import { IClaim } from "../../../../shared/kills";
+import { IUser } from "../../../../shared/users";
+import { Sdk } from "../../sdk/sdk";
+
+/**
+ * Props for an ClaimsTable component.
+ */
+export interface IClaimsTableProps {
+    /**
+     * Information on the current admin.
+     */
+    admin: IUser;
+
+    /**
+     * Any active kill claims related to the user, if not anonymous.
+     */
+    claims?: IClaim[];
+
+    /**
+     * Wrapper around the server API.
+     */
+    sdk: Sdk;
+}
+
+/**
+ * State for a ClaimsTable component.
+ */
+interface IClaimsTableState { }
+
+/**
+ * Component for an editable user's field.
+ */
+export class ClaimsTable extends React.Component<IClaimsTableProps, IClaimsTableState> {
+    /**
+     * Renders the component.
+     * 
+     * @returns The rendered component.
+     */
+    public render(): JSX.Element {
+        return (
+            <table className="claims-table">
+                <thead>
+                    <tr>
+                        <th>Killer</th>
+                        <th>Victim</th>
+                        <th>Time</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {this.props.claims.map((claim: IClaim): JSX.Element => {
+                        return this.renderClaim(claim);
+                    })}
+                </tbody>
+            </table>);
+    }
+
+    /**
+     * Renders a single claim row.
+     * 
+     * @param claim   A claim to render.
+     * @returns The rendered claim.
+     */
+    private renderClaim(claim: IClaim): JSX.Element {
+        return (
+            <tr>
+                <td>{claim.killer}</td>
+                <td>{claim.victim}</td>
+                <td>{claim.timestamp}</td>
+                <td>(soon)</td>
+            </tr>);
+    }
+}

--- a/src/site/scripts/components/apps/app.tsx
+++ b/src/site/scripts/components/apps/app.tsx
@@ -113,6 +113,7 @@ export class App extends React.Component<void, IAppState> {
                 return (
                     <AppAdmin
                         admin={this.state.user}
+                        claims={this.state.claims}
                         leaders={this.state.leaders}
                         notifications={this.state.notifications}
                         rounds={this.state.rounds}

--- a/src/site/scripts/components/apps/app.tsx
+++ b/src/site/scripts/components/apps/app.tsx
@@ -222,6 +222,12 @@ export class App extends React.Component<void, IAppState> {
             killer.kills += 1;
         }
 
+        console.log("Notification", notification, "against", newState.claims);
+        if (notification.codename === this.state.user.codename) {
+            newState.claims = newState.claims.filter(
+                (claim: IClaim): boolean => claim.killer !== this.state.user.alias);
+        }
+
         return newState;
     }
 

--- a/src/site/scripts/components/apps/appadmin.tsx
+++ b/src/site/scripts/components/apps/appadmin.tsx
@@ -59,7 +59,6 @@ export class AppAdmin extends React.Component<IAppAdminProps, void> {
      * @returns The rendered component.
      */
     public render(): JSX.Element {
-        console.log("Claims", this.props.claims);
         return (
             <div id="app" className="app-admin">
                 <section id="profile">

--- a/src/site/scripts/components/apps/appadmin.tsx
+++ b/src/site/scripts/components/apps/appadmin.tsx
@@ -2,6 +2,7 @@
 
 "use strict";
 import * as React from "react";
+import { IClaim } from "../../../../shared/kills";
 import { INotification } from "../../../../shared/notifications";
 import { IRound } from "../../../../shared/rounds";
 import { ILeader, IUser } from "../../../../shared/users";
@@ -9,6 +10,7 @@ import { ActionButton } from "../profile/actionbutton";
 import { Greeting } from "../profile/greeting";
 import { Sdk } from "../../sdk/sdk";
 import { Sidebar } from "../sidebar/sidebar";
+import { ClaimsTable } from "../admin/claimstable";
 import { UsersImporter } from "../admin/usersimporter";
 import { UsersTables } from "../admin/userstables";
 
@@ -20,6 +22,11 @@ export interface IAppAdminProps {
      * Information on the admin.
      */
     admin: IUser;
+
+    /**
+     * Any active kill claims related to the user, if not anonymous.
+     */
+    claims?: IClaim[];
 
     /**
      * Leaders to be shown in the sidebar.
@@ -52,6 +59,7 @@ export class AppAdmin extends React.Component<IAppAdminProps, void> {
      * @returns The rendered component.
      */
     public render(): JSX.Element {
+        console.log("Claims", this.props.claims);
         return (
             <div id="app" className="app-admin">
                 <section id="profile">
@@ -61,6 +69,8 @@ export class AppAdmin extends React.Component<IAppAdminProps, void> {
                     <div className="area greeting-area">
                         <Greeting admin={true} codename={this.props.admin.codename} />
                     </div>
+
+                    <ClaimsTable admin={this.props.admin} claims={this.props.claims} sdk={this.props.sdk} />
 
                     <UsersTables admin={this.props.admin} sdk={this.props.sdk} />
                     <UsersImporter

--- a/src/site/scripts/components/profile/actions.tsx
+++ b/src/site/scripts/components/profile/actions.tsx
@@ -2,6 +2,7 @@
 
 "use strict";
 import * as React from "react";
+import { IClaim } from "../../../../shared/kills";
 import { IRound } from "../../../../shared/rounds";
 import { ActionButton } from "./actionbutton";
 
@@ -13,6 +14,11 @@ export interface IActionProps {
      * Whether the user is alive.
      */
     alive: boolean;
+
+    /**
+     * Active claims related to the user.
+     */
+    claims: IClaim[];
 
     /**
      * Handler for the user reporting their own death.
@@ -54,7 +60,7 @@ export class Actions extends React.Component<IActionProps, void> {
 
         return (
             <div className="actions actions-alive">
-                <ActionButton action={(): void => this.props.onKill()} text="Report a kill!" />
+                {this.props.claims.length === 0 && <ActionButton action={(): void => this.props.onKill()} text="Report a kill!" />}
                 <ActionButton action={(): void => this.props.onDeath()} text="Are you dead?" />
             </div>);
     }

--- a/src/site/scripts/components/profile/profile.tsx
+++ b/src/site/scripts/components/profile/profile.tsx
@@ -45,6 +45,7 @@ export class Profile extends React.Component<IAppUserProps, void> {
                     <h3>Actions</h3>
                     <Actions
                         alive={this.props.user.alive}
+                        claims={this.props.claims}
                         onDeath={(): void => { this.onDeath(); }}
                         onKill={(): void => { this.onKill(); }}
                         rounds={this.props.rounds}

--- a/src/site/scripts/sdk/sdk.ts
+++ b/src/site/scripts/sdk/sdk.ts
@@ -64,7 +64,7 @@ export class Sdk {
     }
 
     /**
-     * Retrieves active kill claims on or by the user.
+     * Retrieves kill claims the user is allowed to see.
      * 
      * @param credentials   The submitting user credentials.
      * @returns A promise for the user's active kill claims.

--- a/src/site/scripts/sdk/sdk.ts
+++ b/src/site/scripts/sdk/sdk.ts
@@ -73,17 +73,7 @@ export class Sdk {
         return this.sendAjaxRequest(
             "GET",
             "api/claims",
-            credentials,
-            {
-                $or: [
-                    {
-                        killer: credentials.alias
-                    },
-                    {
-                        victim: credentials.alias
-                    }
-                ]
-            });
+            credentials);
     }
 
     /**

--- a/src/site/styles/layout.less
+++ b/src/site/styles/layout.less
@@ -85,7 +85,7 @@ input {
 }
 
 .actions {
-    padding-bottom: 70px;
+    padding-bottom: 35px;
 }
 
 .action {
@@ -191,6 +191,7 @@ input {
     }
 
     .greeting-area {
+        margin-bottom: 21px;
         padding-left: 14px;
     }
 

--- a/src/site/styles/layout.less
+++ b/src/site/styles/layout.less
@@ -61,6 +61,10 @@ input {
     text-align: center;
 }
 
+.messages-container {
+    margin-top: 14px;
+}
+
 .leaderboard {
     margin: auto;
     max-width: 350px; 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,7 @@
         "src/site/scripts/components/apps/appadmin.tsx",
         "src/site/scripts/components/apps/appanonymous.tsx",
         "src/site/scripts/components/apps/appuser.tsx",
+        "src/site/scripts/components/admin/claimstable.tsx",
         "src/site/scripts/components/admin/userfield.tsx",
         "src/site/scripts/components/admin/userstable.tsx",
         "src/site/scripts/components/admin/usersimporter.tsx",


### PR DESCRIPTION
Significantly improves UI and gameplay around claims.

Server-side, they'll now be deleted when a kill comes through. 
Client-side, profiles now correctly update when claims go through. The admin page also has a list of claims.