### PR TITLE
Fixed confirmation dialog styles

### DIFF
--- a/src/site/scripts/components/profile/confirmationdialog.tsx
+++ b/src/site/scripts/components/profile/confirmationdialog.tsx
@@ -18,9 +18,9 @@ export interface IConfirmationDialogProps {
     confirmationText: string;
 
     /**
-     * The action to execute on cancel.
+     * Closes the confirmation dialog.
      */
-    onCancel: () => void;
+    close: () => void;
 }
 
 /**
@@ -28,18 +28,23 @@ export interface IConfirmationDialogProps {
  */
 export const ConfirmationDialog: React.StatelessComponent<IConfirmationDialogProps> = (props: IConfirmationDialogProps): JSX.Element => {
     return (
-        <div className="action-confirmation-container">
-            <div className="action-confirmation-text">{props.confirmationText}</div>
-            <div className="action-confirmation-buttons">
-                <input
-                    onClick={props.onCancel}
-                    type="button"
-                    value="Cancel" />
-                <input
-                    className="action-confirm"
-                    onClick={props.action}
-                    type="button"
-                    value="Confirm" />
+        <section className="confirmation-dialog">
+            <div className="confirmation-dialog-display">
+                <p>{props.confirmationText}</p>
+                <div>
+                    <input
+                        onClick={props.close}
+                        type="button"
+                        value="Cancel" />
+                    <input
+                        className="action-confirm"
+                        onClick={(): void => {
+                            props.action();
+                            props.close();
+                        }}
+                        type="button"
+                        value="Confirm" />
+                </div>
             </div>
-        </div>);
+        </section>);
 };

--- a/src/site/styles/layout.less
+++ b/src/site/styles/layout.less
@@ -93,48 +93,6 @@ input {
     position: relative;
 }
 
-.action-confirmation { 
-    .action-confirmation-overlay {
-        z-index: 200;
-        background: black;
-        position: fixed;
-        opacity: .5;
-        width: 100%;
-        height: 100%;
-        bottom: 0;
-        left: 0;
-        top: 0;
-        right: 0;
-    }
-
-    .action-confirmation-container {
-        position: fixed;
-        left: 0;
-        right: 0;
-        margin: -15% auto;
-        background: white;
-        z-index: 300;
-        width: 500px;
-        height: 200px;
-        
-        .action-confirmation-text {
-            word-wrap: break-word; 
-            position: relative;
-            top: 30%;
-        }
-        
-        .action-confirmation-buttons {
-            display: table-row;
-            position: absolute;
-            bottom: 0;
-            margin-bottom: 12px;
-            input {
-                display: table-column;
-            }
-        }     
-    }
-}
-
 .action-small {
     input {
         margin: 0;
@@ -144,7 +102,30 @@ input {
     }
 }
 
-#logout .action-Sign-Out {
+.confirmation-dialog {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.confirmation-dialog-display {
+    padding: 35px 49px;
+    max-width: 100%;
+    flex: none;
+    box-sizing: border-box;
+    background: white;
+
+    p {
+        padding-bottom: 21px;
+    }
+}
+
+#logout .action-sign-out {
     position: absolute;
     top: 0;
     right: 0;
@@ -222,9 +203,5 @@ input {
 
     .greeting-area {
         padding-left: 14px;
-    }
-
-    .action-confirmation {
-        top: 100%;
     }
 }

--- a/src/site/styles/theme.less
+++ b/src/site/styles/theme.less
@@ -195,15 +195,9 @@ input[type=submit] {
     margin-top: 28px;
 }
 
-.action-confirmation {
-    opacity: 0;
-    display: none;
-    transition: 175ms opacity;
-
-    .action-expanded & {
-        display: block;
-        opacity: 1;
-    }
+.confirmation-dialog {
+    background: @color-background-translucent;
+    z-index: 10;
 }
 
 input.action-confirm {

--- a/src/site/styles/variables.less
+++ b/src/site/styles/variables.less
@@ -1,6 +1,7 @@
 @color-background-dark: #283542;
 @color-background-medium: #eaeaea;
 @color-background-light: #fefeff;
+@color-background-translucent: rgba(0, 0, 0, .49);
 @color-font-light: #ccccd0;
 @color-font-medium: #969696;
 @color-font-dark: #494949;


### PR DESCRIPTION
They weren't mobile friendly, and were glitchy on Chrome/Windows.

Previous style was to have two elements, an overlay and container, where
the overlay gave a translucent background and the container was
center-positioned via table displays with a white background. This is
risky structure and a bit complicated.

Now, the overlay contains the container, and they use flexbox for
centering.