### PR TITLE
Fixed target updating in killUserQuietly

### DIFF
--- a/src/site/scripts/sdk/sdk.ts
+++ b/src/site/scripts/sdk/sdk.ts
@@ -144,7 +144,7 @@ export class Sdk {
                 // Update the killer's target to be the victim's target
                 {
                     filter: {
-                        target: killer.alias
+                        alias: killer.alias
                     },
                     updated: {
                         target: victim.target


### PR DESCRIPTION
It should filter on the killer's alias, not who's targeting the killer.